### PR TITLE
删除 setInterval 日志打印

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,6 @@ let deepCopy = (d) => {
 function Tracker() {
 	console.notice(`==========fibos-tracker==========\n\nDBconnString: ${Config.DBconnString.replace(/:[^:]*@/, ":*****@")}\n\n==========fibos-tracker==========`);
 
-	let timer;
 	let fibos;
 	let hookEvents = {};
 	let sys_bn;
@@ -59,13 +58,6 @@ function Tracker() {
 
 		return true;
 	}
-
-
-	let work = () => {
-		console.notice(`\n\n==========fibos-tracker==========\n\ncaches-size:${caches.size}\n\n${new Date()}\n\n==========fibos-tracker==========`);
-	};
-
-	this.work = work;
 
 	this.app = app;
 
@@ -257,14 +249,12 @@ function Tracker() {
 			}
 		});
 
-		timer = setInterval(work, 5 * 1000);
 	}
 
 	this.diagram = () => fs.writeTextFile(process.cwd() + '/diagram.svg', app.diagram());
 
 	this.stop = () => {
 		if (fibos) fibos.stop();
-		timer.clear();
 		process.exit();
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "fibos-tracker",
 	"main": "./lib/",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "a tracking data and api service based on FIBOS/EOS blockchain nodes.",
 	"scripts": {
 		"test": "fibos test",


### PR DESCRIPTION
- 删除打印当前缓存长度定时器，删除该定时器后，可以使带 tracekr 的节点更加安全的退出。
- 升级 fibos-tracker 版本到 1.3.2