### PR TITLE
增加区块高度为1时的判断，避免replay时因post方法无法调用而抛错

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -201,6 +201,8 @@ function Tracker() {
 						arr.push(now_block);
 						let previous = now_block.previous;
 						now_block = block_caches.get(previous, (previous) => {
+							if (previous == "0000000000000000000000000000000000000000000000000000000000000000") return null;
+
 							let block = db.models.blocks.oneSync({
 								producer_block_id: previous
 							});


### PR DESCRIPTION
使用 fibos 进行 replay 时，由于节点chain插件并未初始化完成，导致 fibos.post() 方法无法使用。

tracker 代码逻辑中，replay 到 **1** 块时，会通过 fibos.post() 查找 「前一块」区块数据而导致报错。



